### PR TITLE
fix idalTree already exits error

### DIFF
--- a/npm/Dockerfile
+++ b/npm/Dockerfile
@@ -1,5 +1,4 @@
 FROM node:15.9.0-alpine3.11
-#FROM node:10.21.0-alpine3.9
 
 RUN apk add --no-cache --virtual build-dependencies \
     vim \
@@ -10,6 +9,7 @@ RUN apk add --no-cache --virtual build-dependencies \
     git \
     g++
 
+WORKDIR /work
 RUN npm init -y
 RUN npm config set unsafe-perm true
 RUN npm install -g truffle


### PR DESCRIPTION
https://stackoverflow.com/questions/57534295/npm-err-tracker-idealtree-already-exists-while-creating-the-docker-image-for

node15からDockerで動かすときにWORKDIRを指定していないと/で実行されて生じる問題。